### PR TITLE
Fix do not remove retention discounts and holidays

### DIFF
--- a/src/main/scala/com/gu/CheckPriceRisePostConditions.scala
+++ b/src/main/scala/com/gu/CheckPriceRisePostConditions.scala
@@ -56,7 +56,7 @@ object CheckPriceRisePostConditions {
           .filter(_.lastChangeType.contains("Remove"))
           .exists(_.productRatePlanId == currentGuardianWeeklySubscription.productRatePlanId),
       CurrencyDidNotChange -> Try(newGuardianWeeklyRatePlans.head.ratePlanCharges.head.currency == accountBefore.billingAndPayment.currency).getOrElse(false),
-      PriceHasBeenRaised -> Try(newGuardianWeeklyRatePlans.head.ratePlanCharges.head.price == priceRise.newPrice).getOrElse(false),
+      PriceHasBeenRaised -> Try(newGuardianWeeklyRatePlans.head.ratePlanCharges.head.price.get == priceRise.newPrice).getOrElse(false),
       DeliveryCountryDidNotChange -> (accountBefore.soldToContact.country == accountAfter.soldToContact.country),
     ).partition(_._2)
 

--- a/src/main/scala/com/gu/Config.scala
+++ b/src/main/scala/com/gu/Config.scala
@@ -88,15 +88,16 @@ object Config {
         case _ => "2c92c0f965f2121e01660fb1f1057b1a"
       }
 
-    // Do not remove Holiday and Retention Discounts
+    // Do not remove Holiday and Retention Discounts (Cancellation Save Discount)
     val doNotRemoveProductRatePlanIds: List[String] =
       Config.Zuora.stage match {
         case "DEV" | "dev" => List(
-          "2c92c0f9-6716-86a2-0167-1d14b5e5771e", // "name":"Guardian Weekly Holiday Credit"
-          "", // TODO: Add Retention Discounts
+          "2c92c0f9671686a201671d14b5e5771e", // "name":"Guardian Weekly Holiday Credit"
+          "2c92c0f962cec7990162d3882afc52dd", // "name":"Cancellation Save Discount - 25% off for 3 months"
+          "2c92c0f862ceb7050162d393b0ff6df7", // "name":"Cancellation Save Discount - 50% off for 3 months"
         )
         case "PROD" | "prod" => List(
-          ""
+          "" // TODO: Add prod stuff everywhere
         )
         case _ => List(
           ""

--- a/src/main/scala/com/gu/CurrentGuardianWeeklySubscription.scala
+++ b/src/main/scala/com/gu/CurrentGuardianWeeklySubscription.scala
@@ -80,7 +80,7 @@ object CurrentGuardianWeeklySubscription {
         CurrentGuardianWeeklySubscription(
           subscriptionNumber = subscription.subscriptionNumber,
           billingPeriod = currentGuardianWeeklyRatePlan.ratePlanCharges.head.billingPeriod,
-          price = currentGuardianWeeklyRatePlan.ratePlanCharges.head.price,
+          price = currentGuardianWeeklyRatePlan.ratePlanCharges.head.price.get,
           currency = account.billingAndPayment.currency,
           country = account.soldToContact.country,
           invoicedPeriod = CurrentInvoicedPeriod(

--- a/src/main/scala/com/gu/NewGuardianWeeklySubscription.scala
+++ b/src/main/scala/com/gu/NewGuardianWeeklySubscription.scala
@@ -44,6 +44,7 @@ object NewGuardianWeeklySubscription {
 
     assert(newRatePlans.size == 1, "NewGuardianWeeklyRatePlanExists not satisfied")
     assert(newRatePlans.head.ratePlanCharges.size == 1, "NewGuardianWeeklyRatePlanHasOnlyOneCharge not satisfied ")
+    assert(newRatePlans.head.ratePlanCharges.head.price.isDefined, "Price should exist")
 
     val newRatePlan = newRatePlans.head
     val newRatePlanCharge = newRatePlan.ratePlanCharges.head
@@ -52,7 +53,7 @@ object NewGuardianWeeklySubscription {
 
     NewGuardianWeeklySubscription(
       subscriptionAfterPriceRise.subscriptionNumber,
-      newRatePlanCharge.price,
+      newRatePlanCharge.price.get,
       newRatePlanCharge.currency,
       accountAfterPriceRise.soldToContact.country,
       newProductRatePlanId,

--- a/src/main/scala/com/gu/RemoveRatePlans.scala
+++ b/src/main/scala/com/gu/RemoveRatePlans.scala
@@ -11,11 +11,13 @@ object RemoveRatePlans {
       currentGuardianWeeklySubscription: CurrentGuardianWeeklySubscription,
       priceRise: PriceRise
   ): List[RemoveRatePlan] = {
+
+    import Config.Zuora._
     val removeRatePlans: List[RemoveRatePlan] =
-      subscription.ratePlans
-        .map(_.id)
-        .filterNot(Config.Zuora.doNotRemoveProductRatePlanIds.contains)
-        .map(ratePlanId => RemoveRatePlan(ratePlanId, priceRise.priceRiseDate))
+      subscription
+        .ratePlans
+        .filterNot(ratePlan => doNotRemoveProductRatePlanIds.contains(ratePlan.productRatePlanId))
+        .map(ratePlan => RemoveRatePlan(ratePlan.id, priceRise.priceRiseDate))
 
     assert(removeRatePlans.map(_.ratePlanId).contains(currentGuardianWeeklySubscription.ratePlanId), "Current Guardian Weekly rate plan should be removed.")
     removeRatePlans

--- a/src/main/scala/com/gu/ZuoraClient.scala
+++ b/src/main/scala/com/gu/ZuoraClient.scala
@@ -11,7 +11,7 @@ case class RatePlanCharge(
   id: String,
   productRatePlanChargeId: String,
   currency: String,
-  price: Float,
+  price: Option[Float],
   billingPeriod: String,
   effectiveStartDate: LocalDate,
   effectiveEndDate: LocalDate,


### PR DESCRIPTION
* `Cancellation Save Discount` product rate plan does not have price, so we need to make it `Option`
*  `RemoveRatePlans` should filter on `productRatePlanId`, NOT `ratePlanId`
* `ThereDoesNotExistAFutureAmendmentOnThePriceRiseDate` should take into account holidays and retention discounts