### PR TITLE
Add dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,33 @@ Make sure to run the script after the bill run completes for the day. Currently 
     ```
     sbt "run file.csv"
     ```
-3. Tail the logs: `tail -f logs/application.log`
+    
+3. Choose between dry run (only checks pre-conditions and outputs stats) and main run (write to Zuora):
+
+    ```
+    Multiple main classes detected, select one to run:
+
+     [1] com.gu.DryRunner
+     [2] com.gu.Main
+    [info] Packaging /Users/mgalic/sandbox/zuora-price-riser/target/scala-2.12/zuora-price-riser_2.12-0.1.0-SNAPSHOT.jar ...
+
+    Enter number: [info] Done packaging.
+    1
+
+    [info] Running com.gu.DryRunner subs.csv
+    2018-12-19 19:00:43,518 [INFO] - Start dry run processing subs.csv...
+    2018-12-19 19:00:45,993 [INFO] - Dry run completed for subs.csv
+    2018-12-19 19:00:45,993 [INFO] - --------------------------------------------------------------
+    2018-12-19 19:00:45,993 [INFO] - Results (count):
+    2018-12-19 19:00:45,993 [INFO] - --------------------------------------------------------------
+    2018-12-19 19:00:45,994 [INFO] - Unsatisfied PriceIsWithinReasonableBounds: 2
+    2018-12-19 19:00:45,994 [INFO] - Unsatisfied BillingPeriodIsQuarterlyOrAnnually: 1
+    2018-12-19 19:00:45,994 [INFO] - Unsatisfied SubscriptionIsAutoRenewable: 2
+    2018-12-19 19:00:45,994 [INFO] - Price rise already applied: 1
+    2018-12-19 19:00:45,994 [INFO] - Term extension applied: 0
+    ```
+ 
+4. Tail the logs: `tail -f logs/application.log`
 
 ## Errors handling
 

--- a/src/main/scala/com/gu/DryRunner.scala
+++ b/src/main/scala/com/gu/DryRunner.scala
@@ -1,0 +1,63 @@
+package com.gu
+
+import com.typesafe.scalalogging.LazyLogging
+
+/**
+  * Check pre-conditions for all import records, and outputs stats on failed conditions.
+  * Do not write to Zuora.
+  */
+object DryRunner extends App with LazyLogging {
+  if (args.length == 0)
+    Abort("Please provide import filename")
+  val filename = args(0)
+
+  logger.info(s"Start dry run processing $filename...")
+
+  var unsatisfiedPreConditionsCount = List.empty[Any]
+  var alreadyAppliedCount = 0
+  var termExtensionCount = 0
+
+  FileImporter.importCsv(filename).foreach {
+    case Left(importError) =>
+      Abort(s"Bad import file: $importError")
+
+    case Right(priceRise) =>
+      // **********************************************************************************************
+      // 1. GET CURRENT ZUORA DATA
+      // **********************************************************************************************
+      val newGuardianWeeklyProductCatalogue = ZuoraClient.getNewGuardianWeeklyProductCatalogue()
+      val subscriptionBefore = ZuoraClient.getSubscription(priceRise.subscriptionName)
+      val accountBefore = ZuoraClient.getAccount(subscriptionBefore.accountNumber)
+
+      // **********************************************************************************************
+      // 2. CHECK PRE-CONDITIONS
+      // **********************************************************************************************
+      if (PriceRiseAlreadyApplied(subscriptionBefore, accountBefore, newGuardianWeeklyProductCatalogue))
+        alreadyAppliedCount = alreadyAppliedCount + 1
+      else {
+        val currentSubscription = CurrentGuardianWeeklySubscription(subscriptionBefore, accountBefore)
+        val priceRiseRequest = PriceRiseRequestBuilder(subscriptionBefore, currentSubscription, newGuardianWeeklyProductCatalogue, priceRise)
+        val extendTermRequestOpt = ExtendTermRequestBuilder(subscriptionBefore, currentSubscription)
+
+        val unsatisfiedPreConditions =
+          CheckPriceRisePreConditions(priceRise, subscriptionBefore, accountBefore, newGuardianWeeklyProductCatalogue
+          ) ++ CheckPriceRiseRequestPreConditions(priceRiseRequest, currentSubscription)
+
+        if (unsatisfiedPreConditions.nonEmpty)
+          unsatisfiedPreConditionsCount = unsatisfiedPreConditionsCount ++ unsatisfiedPreConditions
+
+        if (extendTermRequestOpt.isDefined)
+          termExtensionCount = termExtensionCount + 1
+      }
+  }
+
+  logger.info(s"Dry run completed for $filename")
+  logger.info(s"--------------------------------------------------------------")
+  logger.info(s"Results (count):")
+  logger.info(s"--------------------------------------------------------------")
+  unsatisfiedPreConditionsCount
+    .groupBy(identity).mapValues(_.size) // https://stackoverflow.com/a/28495085/5205022
+    .foreach { case (precondition, count) => logger.info(s"Unsatisfied $precondition: $count") }
+  logger.info(s"Price rise already applied: $alreadyAppliedCount")
+  logger.info(s"Term extension applied: $termExtensionCount")
+}


### PR DESCRIPTION
```
/**
  * Check pre-conditions for all import records, and outputs stats on failed conditions.
  * Do not write to Zuora.
  */
object DryRunner extends App with LazyLogging
```

Example dry run:
```
Multiple main classes detected, select one to run:

 [1] com.gu.DryRunner
 [2] com.gu.Main
[info] Packaging /Users/mgalic/sandbox/zuora-price-riser/target/scala-2.12/zuora-price-riser_2.12-0.1.0-SNAPSHOT.jar ...

Enter number: [info] Done packaging.
1

[info] Running com.gu.DryRunner subs.csv
2018-12-19 19:00:43,518 [INFO] - Start dry run processing subs.csv...
2018-12-19 19:00:45,993 [INFO] - Dry run completed for subs.csv
2018-12-19 19:00:45,993 [INFO] - --------------------------------------------------------------
2018-12-19 19:00:45,993 [INFO] - Results (count):
2018-12-19 19:00:45,993 [INFO] - --------------------------------------------------------------
2018-12-19 19:00:45,994 [INFO] - Unsatisfied PriceIsWithinReasonableBounds: 2
2018-12-19 19:00:45,994 [INFO] - Unsatisfied BillingPeriodIsQuarterlyOrAnnually: 1
2018-12-19 19:00:45,994 [INFO] - Unsatisfied SubscriptionIsAutoRenewable: 2
2018-12-19 19:00:45,994 [INFO] - Price rise already applied: 1
2018-12-19 19:00:45,994 [INFO] - Term extension applied: 0
```