### PR TITLE
Add skip price rise on different conditions

### DIFF
--- a/src/main/scala/com/gu/Main.scala
+++ b/src/main/scala/com/gu/Main.scala
@@ -29,8 +29,9 @@ object Main extends App with LazyLogging {
       // 2. CHECK PRE-CONDITIONS
       // **************************************************************************************************************
 
-      if (PriceRiseAlreadyApplied(subscriptionBefore, accountBefore, newGuardianWeeklyProductCatalogue)) {
-        logger.info(s"${priceRise.subscriptionName} skipped because price rise already applied")
+      val skipReasons = Skip(subscriptionBefore, accountBefore, newGuardianWeeklyProductCatalogue)
+      if (skipReasons.nonEmpty) {
+        logger.info(s"${priceRise.subscriptionName} skipped because $skipReasons")
       } else {
 
         val currentSubscription = CurrentGuardianWeeklySubscription(subscriptionBefore, accountBefore)

--- a/src/main/scala/com/gu/Skip.scala
+++ b/src/main/scala/com/gu/Skip.scala
@@ -1,0 +1,25 @@
+package com.gu
+
+sealed trait SkipReason
+case object OneOff extends SkipReason
+case object Cancelled extends SkipReason
+case object PriceRiseApplied extends SkipReason
+
+/**
+  * Check if the price rise should be skipped.
+  */
+object Skip {
+  def apply(
+      subscriptionBefore: Subscription,
+      accountBefore: Account,
+      newGuardianWeeklyProductCatalogue: NewGuardianWeeklyProductCatalogue,
+  ): List[SkipReason] = {
+    val (satisfied, _) = List[(SkipReason, Boolean)](
+      OneOff -> (!subscriptionBefore.autoRenew),
+      Cancelled -> (subscriptionBefore.status == "Cancelled"),
+      PriceRiseApplied -> PriceRiseAlreadyApplied(subscriptionBefore, accountBefore, newGuardianWeeklyProductCatalogue),
+    ).partition(_._2)
+
+    satisfied.map(_._1)
+  }
+}


### PR DESCRIPTION
```
 sealed trait SkipReason
 case object OneOff extends SkipReason
 case object Cancelled extends SkipReason
 case object PriceRiseApplied extends SkipReason
```

Example dry run:

```
2018-12-20 14:10:56,429 [INFO] - Start dry run processing subs.csv...
2018-12-20 14:11:11,663 [INFO] - Dry run completed for subs.csv
2018-12-20 14:11:11,663 [INFO] - --------------------------------------------------------------
2018-12-20 14:11:11,663 [INFO] - Results (count):
2018-12-20 14:11:11,663 [INFO] - --------------------------------------------------------------
2018-12-20 14:11:11,666 [INFO] - Skip because OneOff: 3
2018-12-20 14:11:11,666 [INFO] - Skip because PriceRiseApplied: 1
2018-12-20 14:11:11,667 [INFO] - Skip because Cancelled: 1
2018-12-20 14:11:11,667 [INFO] - Term extension applied: 0
```