### PR TITLE
Increase price rise cap to 99%

### DIFF
--- a/src/main/scala/com/gu/Config.scala
+++ b/src/main/scala/com/gu/Config.scala
@@ -90,5 +90,5 @@ object Config {
       }
   }
 
-  val priceRiseFactorCap = 1.34 // cap is 33% rise
+  val priceRiseFactorCap = 1.99 // cap is 99% rise;
 }


### PR DESCRIPTION
Import data contains records not satisfying 33% cap.

Note, this is a separate issue from 33% cap not satisfied due to subscription having discounts.