### PR TITLE
Fix plan selection for subscribers who pay in a non-standard currency

### DIFF
--- a/src/main/scala/com/gu/Country.scala
+++ b/src/main/scala/com/gu/Country.scala
@@ -3,7 +3,7 @@ package com.gu
 import com.gu.i18n.CountryGroup
 
 object Country {
-  def toCurrency(country: String): String =
+  def standardCurrency(country: String): String =
     country match {
       case _ if UK.contains(country) => "GBP"
       case _ if US.contains(country) => "USD"
@@ -14,9 +14,10 @@ object Country {
       case _ if RestOfTheWorld.contains(country) => "USD"
     }
 
-  def toFutureGuardianWeeklyProductId(country: String): String = country match {
+  def toFutureGuardianWeeklyProductId(country: String, currency: String): String = country match {
     case _ if RestOfTheWorld.contains(country) => Config.Zuora.guardianWeeklyRowProductId
-    case _ => Config.Zuora.guardianWeeklyDomesticProductId
+    case _ if standardCurrency(country) == currency => Config.Zuora.guardianWeeklyDomesticProductId
+    case _ => Config.Zuora.guardianWeeklyRowProductId
   }
 
   private val UK = CountryGroup.UK.countries.map(_.name)

--- a/src/main/scala/com/gu/NewGuardianWeeklySubscription.scala
+++ b/src/main/scala/com/gu/NewGuardianWeeklySubscription.scala
@@ -88,7 +88,7 @@ object GuardianWeeklyProduct {
       newGuardianWeeklyProductCatalogue: NewGuardianWeeklyProductCatalogue
   ): GuardianWeeklyProduct = {
 
-    (Country.toFutureGuardianWeeklyProductId(currentGuardianWeeklySubscription.country) match {
+    (Country.toFutureGuardianWeeklyProductId(currentGuardianWeeklySubscription.country, currentGuardianWeeklySubscription.currency) match {
       case Config.Zuora.guardianWeeklyDomesticProductId => newGuardianWeeklyProductCatalogue.domestic
       case Config.Zuora.guardianWeeklyRowProductId => newGuardianWeeklyProductCatalogue.restOfTheWorld
     })

--- a/src/test/scala/com/gu/NewGuardianWeeklySubscriptionSpec.scala
+++ b/src/test/scala/com/gu/NewGuardianWeeklySubscriptionSpec.scala
@@ -1,0 +1,78 @@
+package com.gu
+
+import org.joda.time.LocalDate
+import org.scalatest.{FlatSpec, Matchers}
+
+class NewGuardianWeeklySubscriptionSpec extends FlatSpec with Matchers {
+
+  val genericSubscription = CurrentGuardianWeeklySubscription(
+    subscriptionNumber = "A-S123456789",
+    billingPeriod = "",
+    price = 10,
+    currency = "",
+    country = "",
+    invoicedPeriod = CurrentInvoicedPeriod(LocalDate.now.minusMonths(2), LocalDate.now.plusMonths(1)),
+    ratePlanId = "rpId1",
+    productRatePlanId = "prRpId1"
+  )
+
+  "GuardianWeeklyProduct" should "select Domestic (Quarterly) for a subscriber who currently pays quarterly in GBP and has the magazine delivered to the UK" in {
+    val currentGuardianWeeklySubscription = genericSubscription.copy(billingPeriod = "Quarter", currency = "GBP", country = "United Kingdom")
+    val selection = GuardianWeeklyProduct(currentGuardianWeeklySubscription, DummyCatalog.catalog)
+    assert(selection == DummyCatalog.domesticQuarterly)
+  }
+
+  "GuardianWeeklyProduct" should "select Domestic (Annual) for a subscriber who currently pays annually in USD and has the magazine delivered to the US" in {
+    val currentGuardianWeeklySubscription = genericSubscription.copy(billingPeriod = "Annual", currency = "USD", country = "United States")
+    val selection = GuardianWeeklyProduct(currentGuardianWeeklySubscription, DummyCatalog.catalog)
+    assert(selection == DummyCatalog.domesticAnnual)
+  }
+
+  "GuardianWeeklyProduct" should "select ROW (Quarterly) for a subscriber who currently pays quarterly in USD and has the magazine delivered to Afghanistan" in {
+    val currentGuardianWeeklySubscription = genericSubscription.copy(billingPeriod = "Quarter", currency = "USD", country = "Afghanistan")
+    val selection = GuardianWeeklyProduct(currentGuardianWeeklySubscription, DummyCatalog.catalog)
+    assert(selection == DummyCatalog.rowQuarterly)
+  }
+
+  "GuardianWeeklyProduct" should "select ROW (Annual) for a subscriber who currently pays annually in GBP and has the magazine delivered to Bahrain" in {
+    val currentGuardianWeeklySubscription = genericSubscription.copy(billingPeriod = "Annual", currency = "GBP", country = "Bahrain")
+    val selection = GuardianWeeklyProduct(currentGuardianWeeklySubscription, DummyCatalog.catalog)
+    assert(selection == DummyCatalog.rowAnnual)
+  }
+
+  "GuardianWeeklyProduct" should "select ROW (Quarterly) for a subscriber who currently pays quarterly in GBP and has the magazine delivered to Germany" in {
+    val currentGuardianWeeklySubscription = genericSubscription.copy(billingPeriod = "Quarter", currency = "GBP", country = "Germany")
+    val selection = GuardianWeeklyProduct(currentGuardianWeeklySubscription, DummyCatalog.catalog)
+    assert(selection == DummyCatalog.rowQuarterly)
+  }
+
+  "GuardianWeeklyProduct" should "select ROW (Annual) for a subscriber who currently pays annually in AUD and has the magazine delivered to the US" in {
+    val currentGuardianWeeklySubscription = genericSubscription.copy(billingPeriod = "Annual", currency = "AUD", country = "United States")
+    val selection = GuardianWeeklyProduct(currentGuardianWeeklySubscription, DummyCatalog.catalog)
+    assert(selection == DummyCatalog.rowAnnual)
+  }
+
+}
+
+object DummyCatalog {
+
+  val genericWeeklyProduct = GuardianWeeklyProduct(
+    productRatePlanName = "GW",
+    billingPeriod = "Quarter",
+    productRatePlanId = "id1",
+    productRatePlanChargeId = "id2",
+    pricing = List(),
+    taxCode = "Guardian Weekly"
+  )
+
+  val domesticQuarterly = genericWeeklyProduct.copy(productRatePlanName = "GW Oct 18 - Quarterly - Domestic")
+  val domesticAnnual = genericWeeklyProduct.copy(productRatePlanName = "GW Oct 18 - Annual - Domestic", billingPeriod = "Annual")
+  val domestic = List(domesticQuarterly, domesticAnnual)
+
+  val rowQuarterly = genericWeeklyProduct.copy(productRatePlanName = "GW Oct 18 - Quarterly - ROW")
+  val rowAnnual = genericWeeklyProduct.copy(productRatePlanName = "GW Oct 18 - Annual - ROW", billingPeriod = "Annual")
+  val restOfWorld = List(rowQuarterly, rowAnnual)
+
+  val catalog = NewGuardianWeeklyProductCatalogue(domestic, restOfWorld)
+
+}


### PR DESCRIPTION
If a subscriber uses a non-standard currency for a delivery country (e.g. paying in GBP whilst having magazines delivered to Germany), then they should be on the Rest of World plan.