### PR TITLE
Execute getNewGuardianWeeklyProductCatalogue only once

### DIFF
--- a/src/main/scala/com/gu/DryRunner.scala
+++ b/src/main/scala/com/gu/DryRunner.scala
@@ -26,7 +26,7 @@ object DryRunner extends App with LazyLogging {
       // **********************************************************************************************
       // 1. GET CURRENT ZUORA DATA
       // **********************************************************************************************
-      val newGuardianWeeklyProductCatalogue = ZuoraClient.getNewGuardianWeeklyProductCatalogue()
+      val newGuardianWeeklyProductCatalogue = ZuoraClient.getNewGuardianWeeklyProductCatalogue
       val subscriptionBefore = ZuoraClient.getSubscription(priceRise.subscriptionName)
       val accountBefore = ZuoraClient.getAccount(subscriptionBefore.accountNumber)
 

--- a/src/main/scala/com/gu/Main.scala
+++ b/src/main/scala/com/gu/Main.scala
@@ -30,7 +30,7 @@ object Main extends App with LazyLogging {
       // **************************************************************************************************************
       // 1. GET CURRENT ZUORA DATA
       // **************************************************************************************************************
-      val newGuardianWeeklyProductCatalogue = ZuoraClient.getNewGuardianWeeklyProductCatalogue()
+      val newGuardianWeeklyProductCatalogue = ZuoraClient.getNewGuardianWeeklyProductCatalogue
       val subscriptionBefore = ZuoraClient.getSubscription(priceRise.subscriptionName)
       val accountBefore = ZuoraClient.getAccount(subscriptionBefore.accountNumber)
 

--- a/src/main/scala/com/gu/ZuoraClient.scala
+++ b/src/main/scala/com/gu/ZuoraClient.scala
@@ -179,7 +179,7 @@ object ZuoraClient extends ZuoraJsonFormats {
     )
   }
 
-  def getNewGuardianWeeklyProductCatalogue() = NewGuardianWeeklyProductCatalogue(
+  lazy val getNewGuardianWeeklyProductCatalogue = NewGuardianWeeklyProductCatalogue(
     domestic = getGuardianWeeklyProducts(Config.Zuora.guardianWeeklyDomesticProductId),
     restOfTheWorld = getGuardianWeeklyProducts(Config.Zuora.guardianWeeklyRowProductId)
   )


### PR DESCRIPTION
Optimise script - no need to get the new product catalogue for each import record.