### PR TITLE
Collect old pre-price rise IDs in separate object

### DIFF
--- a/src/main/scala/com/gu/CheckPriceRisePreConditions.scala
+++ b/src/main/scala/com/gu/CheckPriceRisePreConditions.scala
@@ -40,7 +40,7 @@ object CheckPriceRisePreConditions {
       TargetPriceRiseIsNotMoreThanTheCap -> (priceRise.newPrice < currentGuardianWeeklySubscription.price * Config.priceRiseFactorCap),
       TargetPriceRiseIsNotMoreThanDefaultProductRatePlanChargePrice -> (priceRise.newPrice <= DefaultCataloguePrice(futureGuardianWeeklyProducts, currentGuardianWeeklySubscription)),
       TargetPriceRiseIsMoreThanTheCurrentPrice -> (priceRise.newPrice > currentGuardianWeeklySubscription.price),
-      CurrentlyActiveProductRatePlanIsGuardianWeeklyRatePlan -> Config.Zuora.guardianWeeklyProductRatePlanIds.contains(currentGuardianWeeklySubscription.productRatePlanId),
+      CurrentlyActiveProductRatePlanIsGuardianWeeklyRatePlan -> Config.Zuora.Old.guardianWeeklyProductRatePlanIds.contains(currentGuardianWeeklySubscription.productRatePlanId),
       BillingPeriodIsQuarterlyOrAnnually -> List("Annual", "Quarter").contains(currentGuardianWeeklySubscription.billingPeriod),
       ThereDoesNotExistAFutureAmendmentOnThePriceRiseDate ->
         Try {

--- a/src/main/scala/com/gu/Config.scala
+++ b/src/main/scala/com/gu/Config.scala
@@ -9,57 +9,30 @@ object Config {
     lazy val client_id: String = conf.getString("zuora.client_id")
     lazy val client_secret: String = conf.getString("zuora.client_secret")
 
-    /**
-        Contains list of all Product Rate Plan IDs for Guardian Weekly obtained manually
-        using the following query:
+    object Old { // Pre-price rise Guardian Weekly
+      val guardianWeeklyProductRatePlanIds: List[String] = stage match {
+          case "DEV" => List(
+            "2c92c0f8574b2b8101574c4a9480068d", // "name":"Guardian Weekly Annual"
+            "2c92c0f8574b2b8101574c4a957706be", // "name":"Guardian Weekly Quarterly"
+            "2c92c0f8574b2be601574c323ca15c7e", // "name":"Guardian Weekly Quarterly"
+            "2c92c0f8574b2be601574c39888d6850", // "name":"Guardian Weekly Annual"
+            "2c92c0f858aa38af0158da325cec0b2e", // "name":"Guardian Weekly Quarterly"
+            "2c92c0f858aa38af0158da325d2f0b3d", // "name":"Guardian Weekly Annual"
+          )
+          case "PROD" => List(
+            // Product: {"id":"2c92a0fd-57d0-a987-0157-d73fa27c3de1","name":"Guardian Weekly Zone A"}
+            "2c92a0fd57d0a9870157d7412f19424f", // "name":"Guardian Weekly Quarterly"
+            "2c92a0ff57d0a0b60157d741e722439a", // "name":"Guardian Weekly Annual"
 
-        POST /query/jobs HTTP/1.1
-        Host: rest.apisandbox.zuora.com
-        Accept: application/json
-        Content-Type: application/json
-        Authorization: Bearer *****************
-        cache-control: no-cache
-        {
-          "query": "select id, name from productrateplan",
-          "outputFormat": "JSON",
-          "compression": "NONE",
-          "retries": 3,
-          "output": {
-            "target": "API_RESPONSE"
-          }
+            // Product: {"id":"2c92a0fe-57d0-a0c4-0157-d74240d35541","name":"Guardian Weekly Zone B"}
+            "2c92a0fe57d0a0c40157d74241005544", // "name":"Guardian Weekly Quarterly"
+            "2c92a0fe57d0a0c40157d74240de5543", // "name":"Guardian Weekly Annual"
+
+            // Product: {"id":"2c92a0ff-58bd-f4eb-0158-f307ecc102ad","name":"Guardian Weekly Zone C"}
+            "2c92a0ff58bdf4eb0158f307ed0e02be", // "name":"Guardian Weekly Quarterly"
+            "2c92a0ff58bdf4eb0158f307eccf02af", // "name":"Guardian Weekly Annual"
+          )
         }
-      */
-    val guardianWeeklyProductRatePlanIds: List[String] = {
-      val dev = List(
-        "2c92c0f8574b2b8101574c4a9480068d", // "name":"Guardian Weekly Annual"
-        "2c92c0f8574b2b8101574c4a957706be", // "name":"Guardian Weekly Quarterly"
-        "2c92c0f8574b2be601574c323ca15c7e", // "name":"Guardian Weekly Quarterly"
-        "2c92c0f8574b2be601574c39888d6850", // "name":"Guardian Weekly Annual"
-        "2c92c0f858aa38af0158da325cec0b2e", // "name":"Guardian Weekly Quarterly"
-        "2c92c0f858aa38af0158da325d2f0b3d", // "name":"Guardian Weekly Annual"}
-        "2c92c0f86716796f016717d9e1465e03", // "name":"GW Nov 19 - Quarterly - Domestic"
-        "2c92c0f965d280590165f16b1b9946c2", // "name":"GW Oct 18 - Annual - Domestic"
-        "2c92c0f965dc30640165f150c0956859", // "name":"GW Oct 18 - Quarterly - Domestic"
-        "2c92c0f965f2122101660fb33ed24a45", // "name":"GW Oct 18 - Annual - ROW"
-        "2c92c0f965f2122101660fb81b745a06", // "name":"GW Oct 18 - Quarterly - ROW"
-      )
-
-      Config.Zuora.stage match {
-        case "DEV" | "dev" => dev
-        case "PROD" | "prod" => List(
-          // Product: {"id":"2c92a0fd-57d0-a987-0157-d73fa27c3de1","name":"Guardian Weekly Zone A"}
-          "2c92a0fd57d0a9870157d7412f19424f", // "name":"Guardian Weekly Quarterly"
-          "2c92a0ff57d0a0b60157d741e722439a", // "name":"Guardian Weekly Annual"
-
-          // Product: {"id":"2c92a0fe-57d0-a0c4-0157-d74240d35541","name":"Guardian Weekly Zone B"}
-          "2c92a0fe57d0a0c40157d74241005544", // "name":"Guardian Weekly Quarterly"
-          "2c92a0fe57d0a0c40157d74240de5543", // "name":"Guardian Weekly Annual"
-
-          // Product: {"id":"2c92a0ff-58bd-f4eb-0158-f307ecc102ad","name":"Guardian Weekly Zone C"}
-          "2c92a0ff58bdf4eb0158f307ed0e02be", // "name":"Guardian Weekly Quarterly"
-          "2c92a0ff58bdf4eb0158f307eccf02af", // "name":"Guardian Weekly Annual"
-        )
-      }
     }
 
     val guardianWeeklyDomesticProductId: String =

--- a/src/main/scala/com/gu/CurrentGuardianWeeklySubscription.scala
+++ b/src/main/scala/com/gu/CurrentGuardianWeeklySubscription.scala
@@ -62,7 +62,7 @@ object CurrentGuardianWeeklySubscription {
       .ratePlans
       .find { ratePlan =>
         List[(CurrentGuardianWeeklyRatePlanCondition, Boolean)](
-          RatePlanIsGuardianWeekly -> Config.Zuora.guardianWeeklyProductRatePlanIds.contains(ratePlan.productRatePlanId),
+          RatePlanIsGuardianWeekly -> Config.Zuora.Old.guardianWeeklyProductRatePlanIds.contains(ratePlan.productRatePlanId),
           RatePlanHasACharge -> ratePlan.ratePlanCharges.nonEmpty,
           RatePlanHasOnlyOneCharge -> (ratePlan.ratePlanCharges.size == 1),
           TodayHasBeenInvoiced ->


### PR DESCRIPTION
Make it distinction between new and old Zuora IDs clearer.

```
         "2c92c0f86716796f016717d9e1465e03", // "name":"GW Nov 19 - Quarterly - Domestic"	
         "2c92c0f965d280590165f16b1b9946c2", // "name":"GW Oct 18 - Annual - Domestic"	
         "2c92c0f965dc30640165f150c0956859", // "name":"GW Oct 18 - Quarterly - Domestic"	
         "2c92c0f965f2122101660fb33ed24a45", // "name":"GW Oct 18 - Annual - ROW"	
         "2c92c0f965f2122101660fb81b745a06", // "name":"GW Oct 18 - Quarterly - ROW"
```

were actually new IDs (DEV) so should not have been in `guardianWeeklyProductRatePlanIds`