### PR TITLE
Check NewGuardianWeeklyProduct against hardcoded new productRatePlanIds

### DIFF
--- a/src/main/scala/com/gu/Config.scala
+++ b/src/main/scala/com/gu/Config.scala
@@ -35,17 +35,40 @@ object Config {
         }
     }
 
-    val guardianWeeklyDomesticProductId: String =
-      Config.Zuora.stage match {
-        case "DEV" | "dev" => "2c92c0f865d272ef0165f14cc19d238a"   // "name":"Guardian Weekly - Domestic"
-        case "PROD" | "prod" => "2c92a0ff6619bf8901661aa3247c4b1d" // "name":"Guardian Weekly - Domestic"
-      }
+    object New {
+      val guardianWeeklyDomesticProductId: String =
+        Config.Zuora.stage match {
+          case "DEV" | "dev" => "2c92c0f865d272ef0165f14cc19d238a"   // "name":"Guardian Weekly - Domestic"
+          case "PROD" | "prod" => "2c92a0ff6619bf8901661aa3247c4b1d" // "name":"Guardian Weekly - Domestic"
+        }
 
-    val guardianWeeklyRowProductId: String =
-      Config.Zuora.stage match {
-        case "DEV" | "dev" => "2c92c0f965f2121e01660fb1f1057b1a"    // "name":"Guardian Weekly - ROW"
-        case "PROD" | "prod" => "2c92a0fe6619b4b901661aaf826435de"  // "name":"Guardian Weekly - ROW"
+      val guardianWeeklyRowProductId: String =
+        Config.Zuora.stage match {
+          case "DEV" | "dev" => "2c92c0f965f2121e01660fb1f1057b1a"    // "name":"Guardian Weekly - ROW"
+          case "PROD" | "prod" => "2c92a0fe6619b4b901661aaf826435de"  // "name":"Guardian Weekly - ROW"
+        }
+
+      val guardianWeeklyProductRatePlanIds: List[String] = stage match {
+        case "DEV" => List(
+          // Product: {"id":"2c92c0f8-65d2-72ef-0165-f14cc19d238a", "name":"Guardian Weekly - Domestic"}
+          "2c92c0f965d280590165f16b1b9946c2", // "name": "GW Oct 18 - Annual - Domestic"
+          "2c92c0f965dc30640165f150c0956859", // "name": "GW Oct 18 - Quarterly - Domestic"
+
+            // Product: {"2c92c0f9-65f2-121e-0166-0fb1f1057b1a", "name":"Guardian Weekly - ROW"}
+          "2c92c0f965f2122101660fb33ed24a45", // "name":"GW Oct 18 - Annual - ROW"
+          "2c92c0f965f2122101660fb81b745a06", // "name":"GW Oct 18 - Quarterly - ROW"
+        )
+        case "PROD" => List(
+          // Product: {"id":"2c92a0ff-6619-bf89-0166-1aa3247c4b1d", "name":"Guardian Weekly - Domestic"}
+          "2c92a0fe6619b4b901661aa8e66c1692", // "name": "GW Oct 18 - Annual - Domestic"
+          "2c92a0fe6619b4b301661aa494392ee2", // "name": "GW Oct 18 - Quarterly - Domestic"
+
+          // Product: {"2c92a0fe-6619-b4b9-0166-1aaf826435de", "name":"Guardian Weekly - ROW"}
+          "2c92a0fe6619b4b601661ab300222651", // "name":"GW Oct 18 - Annual - ROW"
+          "2c92a0086619bf8901661ab02752722f", // "name":"GW Oct 18 - Quarterly - ROW"
+        )
       }
+    }
 
     // Do not remove Holiday and Retention Discounts (Cancellation Save Discount)
     val doNotRemoveProductRatePlanIds: List[String] =

--- a/src/main/scala/com/gu/Country.scala
+++ b/src/main/scala/com/gu/Country.scala
@@ -15,9 +15,9 @@ object Country {
     }
 
   def toFutureGuardianWeeklyProductId(country: String, currency: String): String = country match {
-    case _ if RestOfTheWorld.contains(country) => Config.Zuora.guardianWeeklyRowProductId
-    case _ if standardCurrency(country) == currency => Config.Zuora.guardianWeeklyDomesticProductId
-    case _ => Config.Zuora.guardianWeeklyRowProductId
+    case _ if RestOfTheWorld.contains(country) => Config.Zuora.New.guardianWeeklyRowProductId
+    case _ if standardCurrency(country) == currency => Config.Zuora.New.guardianWeeklyDomesticProductId
+    case _ => Config.Zuora.New.guardianWeeklyRowProductId
   }
 
   private val UK = CountryGroup.UK.countries.map(_.name)

--- a/src/main/scala/com/gu/ZuoraClient.scala
+++ b/src/main/scala/com/gu/ZuoraClient.scala
@@ -155,7 +155,7 @@ object ZuoraClient extends ZuoraJsonFormats {
     }
   }
 
-  def getProductRatePlans(productId: String): List[ProductRatePlan] = {
+  private def getProductRatePlans(productId: String): List[ProductRatePlan] = {
     val response =
       HttpWithLongTimeout(s"$host/v1/rateplan/$productId/productRatePlan")
         .header("Authorization", s"Bearer $accessToken")
@@ -168,22 +168,11 @@ object ZuoraClient extends ZuoraJsonFormats {
     }
   }
 
-  private def getGuardianWeeklyProducts(guardianWeeklyProductId: String): List[NewGuardianWeeklyProduct] = {
-    import Config.Zuora._
-    require(
-      List(guardianWeeklyDomesticProductId, guardianWeeklyRowProductId).contains(guardianWeeklyProductId),
-      "Product ID should represent either 'Guardian Weekly - ROW' or 'Guardian Weekly - Domestic'"
-    )
-    GuardianWeeklyProducts(
-      getProductRatePlans(guardianWeeklyProductId)
-    )
-  }
-
+  // FIXME: Once we enable all currencies we could hardcode this object
   lazy val getNewGuardianWeeklyProductCatalogue = NewGuardianWeeklyProductCatalogue(
-    domestic = getGuardianWeeklyProducts(Config.Zuora.guardianWeeklyDomesticProductId),
-    restOfTheWorld = getGuardianWeeklyProducts(Config.Zuora.guardianWeeklyRowProductId)
+    domestic = NewGuardianWeeklyProducts(getProductRatePlans(Config.Zuora.New.guardianWeeklyDomesticProductId)),
+    restOfTheWorld = NewGuardianWeeklyProducts(getProductRatePlans(Config.Zuora.New.guardianWeeklyRowProductId))
   )
-
 
   /*
   PUT /v1/subscriptions/A-S00047834 HTTP/1.1


### PR DESCRIPTION
* Constrain the concept of `NewGuardianWeeklyProduct` to mean

  - new product (after price rise)
  - Guardian weekly
  - annual or quarterly

* Separate new IDs in their own object 
* FIXME: Once we enable all currencies we could hardcode the new GW product catalogue