### PR TITLE
Add PriceShouldNotChangeOnSubsequentRenewals post condition

### DIFF
--- a/src/main/scala/com/gu/CheckPriceRisePostConditions.scala
+++ b/src/main/scala/com/gu/CheckPriceRisePostConditions.scala
@@ -14,6 +14,7 @@ case object HolidaysAndRetentionDiscountsWereNotRemoved extends PriceRisePostCon
 case object CurrencyDidNotChange extends PriceRisePostCondition
 case object PriceHasBeenRaised extends PriceRisePostCondition
 case object DeliveryCountryDidNotChange extends PriceRisePostCondition
+case object PriceShouldNotChangeOnSubsequentRenewals extends PriceRisePostCondition
 
 /**
   * Checks post-conditions after the price rise has been writen to Zuora.
@@ -58,6 +59,7 @@ object CheckPriceRisePostConditions {
       CurrencyDidNotChange -> Try(newGuardianWeeklyRatePlans.head.ratePlanCharges.head.currency == accountBefore.billingAndPayment.currency).getOrElse(false),
       PriceHasBeenRaised -> Try(newGuardianWeeklyRatePlans.head.ratePlanCharges.head.price.get == priceRise.newPrice).getOrElse(false),
       DeliveryCountryDidNotChange -> (accountBefore.soldToContact.country == accountAfter.soldToContact.country),
+      PriceShouldNotChangeOnSubsequentRenewals -> Try(newGuardianWeeklyRatePlans.head.ratePlanCharges.head.priceChangeOption == "NoChange").getOrElse(false),
     ).partition(_._2)
 
     unsatisfied.map(_._1)

--- a/src/main/scala/com/gu/NewGuardianWeeklySubscription.scala
+++ b/src/main/scala/com/gu/NewGuardianWeeklySubscription.scala
@@ -9,7 +9,7 @@ case class NewGuardianWeeklySubscription(
   currency: String,
   country: String,
   productRatePlanId: String,
-  productRatePlanChargeId: String,
+  productRatePlanChargeId: String
 )
 
 object DefaultCataloguePrice {

--- a/src/main/scala/com/gu/NewGuardianWeeklySubscription.scala
+++ b/src/main/scala/com/gu/NewGuardianWeeklySubscription.scala
@@ -9,7 +9,7 @@ case class NewGuardianWeeklySubscription(
   currency: String,
   country: String,
   productRatePlanId: String,
-  productRatePlanChargeId: String
+  productRatePlanChargeId: String,
 )
 
 object DefaultCataloguePrice {

--- a/src/main/scala/com/gu/ZuoraClient.scala
+++ b/src/main/scala/com/gu/ZuoraClient.scala
@@ -88,7 +88,7 @@ case class Price(
 )
 
 case class RemoveRatePlan(ratePlanId: String, contractEffectiveDate: LocalDate)
-case class ChargeOverride(productRatePlanChargeId: String, price: Float)
+case class ChargeOverride(productRatePlanChargeId: String, price: Float, priceChangeOption: String = "NoChange")
 case class AddProductRatePlan(productRatePlanId: String, contractEffectiveDate: LocalDate, chargeOverrides: Option[List[ChargeOverride]])
 
 case class PriceRiseRequest(

--- a/src/main/scala/com/gu/ZuoraClient.scala
+++ b/src/main/scala/com/gu/ZuoraClient.scala
@@ -17,6 +17,7 @@ case class RatePlanCharge(
   effectiveEndDate: LocalDate,
   processedThroughDate: Option[LocalDate],
   chargedThroughDate: Option[LocalDate],
+  priceChangeOption: String,
 )
 
 case class RatePlan(


### PR DESCRIPTION
`priceChangeOption` 

> Applies an automatic price change when a termed subscription is renewed.

We set it to `NoChange`, that is, the price should not change on subsequent renewals after the price rise.



