### PR TITLE
Add BillingPreview postcondition

### DIFF
--- a/src/main/scala/com/gu/BillingPreview.scala
+++ b/src/main/scala/com/gu/BillingPreview.scala
@@ -1,0 +1,55 @@
+package com.gu
+
+/**
+  * https://{{zuoraUrlPrefix}}/v1/operations/billing-preview returns price without tax applied
+  * so this adds the tax.
+  */
+object BillingPreview {
+  def apply(
+    account: Account,
+    invoiceItem: InvoiceItem
+  ): Float = {
+    if (taxedCountries.contains(account.soldToContact.country)) {
+      val country = account.soldToContact.country
+      val state =  country match {
+        case "Canada" => Some(account.soldToContact.state)
+        case _ => None
+      }
+      val tax = taxBy(country -> state)
+      val chargeAmount = invoiceItem.chargeAmount
+      val chargeWithTax = chargeAmount * (1 + tax)
+      val roundedPrice = (math rint chargeWithTax * 100) / 100 // https://stackoverflow.com/a/11107546/5205022
+      roundedPrice.toFloat
+    }
+    else {
+      invoiceItem.chargeAmount
+    }
+
+  }
+
+  type Country = String
+  type State = String
+  type TaxRate = Double
+  private val taxBy: Map[(Country, Option[State]), TaxRate] = Map(
+    ("Australia", None) -> 0.1,
+    ("Canada", Some("Alberta")) -> 0.05,
+    ("Canada", Some("British Columbia")) -> 0.05,
+    ("Canada", Some("Manitoba")) -> 0.05,
+    ("Canada", Some("New Brunswick")) -> 0.15,
+    ("Canada", Some("Newfoundland and Labrador")) -> 0.15,
+    ("Canada", Some("Nova Scotia")) -> 0.15,
+    ("Canada", Some("Northwest Territories")) -> 0.05,
+    ("Canada", Some("Nunavut")) -> 0.05,
+    ("Canada", Some("Ontario")) -> 0.13,
+    ("Canada", Some("Prince Edward Island")) -> 0.14,
+    ("Canada", Some("Quebec")) -> 0.14975,
+    ("Canada", Some("Saskatchewan")) -> 0.05,
+    ("Canada", Some("Yukon")) -> 0.05,
+    ("France", None) -> 0.021,
+    ("Germany", None) -> 0.07,
+    ("Italy", None) -> 0.008,
+    ("Spain", None) -> 0.04,
+    ("Sweden", None) -> 0.06,
+  )
+  private val taxedCountries: List[Country] = taxBy.keys.map(_._1).toList
+}

--- a/src/test/scala/com/gu/BillingPreviewSpec.scala
+++ b/src/test/scala/com/gu/BillingPreviewSpec.scala
@@ -1,0 +1,162 @@
+package com.gu
+
+import com.gu.FileImporter.PriceRise
+import org.joda.time.LocalDate
+import org.joda.time.format.DateTimeFormat
+import org.json4s.native.JsonMethods.parse
+import org.scalatest._
+
+class BillingPreviewSpec extends FlatSpec with Matchers with ZuoraJsonFormats {
+
+  val rawInvoiceItem =
+    """
+      |        {
+      |            "id": "",
+      |            "subscriptionName": "11111",
+      |            "subscriptionId": "",
+      |            "subscriptionNumber": "11111",
+      |            "serviceStartDate": "2019-01-14",
+      |            "serviceEndDate": "2019-04-13",
+      |            "chargeAmount": 76.19,
+      |            "chargeDescription": "",
+      |            "chargeName": "GW Oct 18 - Quarterly - Domestic",
+      |            "chargeNumber": "",
+      |            "chargeId": "",
+      |            "productName": "Guardian Weekly - Domestic",
+      |            "quantity": 1,
+      |            "taxAmount": 0,
+      |            "unitOfMeasure": "",
+      |            "chargeDate": "2018-12-31 16:23:19",
+      |            "chargeType": "Recurring",
+      |            "processingType": "Charge",
+      |            "appliedToItemId": null
+      |        }
+    """.stripMargin
+
+  val rawAccount =
+    """
+      |{
+      |    "basicInfo": {
+      |        "id": "",
+      |        "name": "11111",
+      |        "accountNumber": "11111",
+      |        "notes": null,
+      |        "status": "Active",
+      |        "crmId": "",
+      |        "batch": "Batch1",
+      |        "invoiceTemplateId": "",
+      |        "communicationProfileId": "",
+      |        "IdentityId__c": "",
+      |        "sfContactId__c": "",
+      |        "CCURN__c": null,
+      |        "SpecialDeliveryInstructions__c": null,
+      |        "NonStandardDataReason__c": null,
+      |        "ProcessingAdvice__c": null,
+      |        "CreatedRequestId__c": null,
+      |        "salesRep": null
+      |    },
+      |    "billingAndPayment": {
+      |        "billCycleDay": 13,
+      |        "currency": "CAD",
+      |        "paymentTerm": "Due Upon Receipt",
+      |        "paymentGateway": "Stripe Gateway 1",
+      |        "invoiceDeliveryPrefsPrint": false,
+      |        "invoiceDeliveryPrefsEmail": true,
+      |        "additionalEmailAddresses": []
+      |    },
+      |    "metrics": {
+      |        "balance": -12,
+      |        "totalInvoiceBalance": 0,
+      |        "creditBalance": 12,
+      |        "contractedMrr": 26.67
+      |    },
+      |    "billToContact": {
+      |        "address1": "",
+      |        "address2": null,
+      |        "city": "",
+      |        "country": "Canada",
+      |        "county": "BC",
+      |        "fax": null,
+      |        "firstName": "",
+      |        "homePhone": null,
+      |        "lastName": "",
+      |        "mobilePhone": null,
+      |        "nickname": null,
+      |        "otherPhone": null,
+      |        "otherPhoneType": null,
+      |        "personalEmail": null,
+      |        "state": "British Columbia",
+      |        "taxRegion": null,
+      |        "workEmail": "",
+      |        "workPhone": "",
+      |        "zipCode": "",
+      |        "Company_Name__c": null,
+      |        "SpecialDeliveryInstructions__c": null,
+      |        "Title__c": "",
+      |        "contactDescription": null
+      |    },
+      |    "soldToContact": {
+      |        "address1": "",
+      |        "address2": null,
+      |        "city": "VICTORIA",
+      |        "country": "Canada",
+      |        "county": "BC",
+      |        "fax": null,
+      |        "firstName": "",
+      |        "homePhone": null,
+      |        "lastName": "",
+      |        "mobilePhone": null,
+      |        "nickname": null,
+      |        "otherPhone": null,
+      |        "otherPhoneType": null,
+      |        "personalEmail": null,
+      |        "state": "British Columbia",
+      |        "taxRegion": null,
+      |        "workEmail": "",
+      |        "workPhone": "",
+      |        "zipCode": "",
+      |        "Company_Name__c": null,
+      |        "SpecialDeliveryInstructions__c": null,
+      |        "Title__c": "",
+      |        "contactDescription": null
+      |    },
+      |    "taxInfo": null,
+      |    "success": true
+      |}
+    """.stripMargin
+
+  "BillingPreview" should "calculate tax for countries with states" in {
+    val zuoraDateFormat = DateTimeFormat.forPattern("yyyy-MM-dd")
+    val priceRise = PriceRise("11111", "", "", LocalDate.parse("2019-01-14", zuoraDateFormat), 60.0f, 80.0f, None)
+    BillingPreview(
+      parse(rawAccount).extract[Account],
+      parse(rawInvoiceItem).extract[InvoiceItem]
+    ) should be (priceRise.newPrice)
+  }
+
+  it should "calculate tax for countries without states" in {
+    val zuoraDateFormat = DateTimeFormat.forPattern("yyyy-MM-dd")
+    val newPrice = 76.19f * (1 + 0.07f)
+    val newPriceRounded = (math rint newPrice * 100) / 100
+    val priceRise = PriceRise("11111", "", "", LocalDate.parse("2019-01-14", zuoraDateFormat), 60.0f, newPriceRounded.toFloat, None)
+    val account = parse(rawAccount).extract[Account]
+    val accountGermanyNoState = account.copy(soldToContact = account.soldToContact.copy(country = "Germany", state = ""))
+
+    BillingPreview(
+      accountGermanyNoState,
+      parse(rawInvoiceItem).extract[InvoiceItem]
+    ) should equal (priceRise.newPrice)
+  }
+
+  it should "not apply tax for countries without tax" in {
+    val zuoraDateFormat = DateTimeFormat.forPattern("yyyy-MM-dd")
+    val priceRise = PriceRise("11111", "", "", LocalDate.parse("2019-01-14", zuoraDateFormat), 60.0f, 76.19f, None)
+    val account = parse(rawAccount).extract[Account]
+    val accountLatviaNoTax = account.copy(soldToContact = account.soldToContact.copy(country = "Latvia", state = ""))
+
+    BillingPreview(
+      accountLatviaNoTax,
+      parse(rawInvoiceItem).extract[InvoiceItem]
+    ) should equal (priceRise.newPrice)
+  }
+}

--- a/src/test/scala/com/gu/NewGuardianWeeklySubscriptionSpec.scala
+++ b/src/test/scala/com/gu/NewGuardianWeeklySubscriptionSpec.scala
@@ -18,12 +18,13 @@ class NewGuardianWeeklySubscriptionSpec extends FlatSpec with Matchers with Zuor
   val newGuardianWeeklyProductCatalogue = Config.Zuora.New.guardianWeeklyProductCatalogue
   val priceRise = PriceRise("A-S00045676", "", "", LocalDate.parse("2019-07-27", zuoraDateFormat), 312.0f, 390.0f, None)
   val currentSubscription = CurrentGuardianWeeklySubscription(subscriptionBefore, accountBefore)
+  val invoiceItem = InvoiceItem("", "", LocalDate.parse("2019-07-27", zuoraDateFormat), LocalDate.parse("2019-07-27", zuoraDateFormat), (390 / 1.1).toFloat, "", "")
 
   val priceRiseRequest = PriceRiseRequestBuilder(subscriptionBefore, currentSubscription, newGuardianWeeklyProductCatalogue, priceRise)
 
   "NewGuardianWeeklySubscription" should "should satisfy all CheckPriceRisePostConditions" in {
     val unsatisfiedPostConditions = CheckPriceRisePostConditions(
-        subscriptionAfter, accountBefore, accountAfter, newGuardianWeeklyProductCatalogue, priceRise, currentSubscription)
+        subscriptionAfter, accountBefore, accountAfter, newGuardianWeeklyProductCatalogue, priceRise, currentSubscription, invoiceItem)
 
     val newGuardianWeeklySubscription = NewGuardianWeeklySubscription(subscriptionAfter, accountAfter, newGuardianWeeklyProductCatalogue)
 
@@ -35,8 +36,8 @@ class NewGuardianWeeklySubscriptionSpec extends FlatSpec with Matchers with Zuor
 
   it should "list failed postconditions" in {
     val unsatisfiedPostConditions = CheckPriceRisePostConditions(
-        subscriptionAfter, accountBefore, accountAfter, newGuardianWeeklyProductCatalogue, priceRise.copy(newPrice = 1000), currentSubscription)
+        subscriptionAfter, accountBefore, accountAfter, newGuardianWeeklyProductCatalogue, priceRise.copy(newPrice = 1000), currentSubscription, invoiceItem)
 
-    unsatisfiedPostConditions should be (List(PriceHasBeenRaised))
+    unsatisfiedPostConditions should be (List(PriceHasBeenRaised, InvoiceShouldHaveTheNewPrice))
   }
 }


### PR DESCRIPTION
Zuora REST API has limited ability feature which allows for invoice preview:
https://www.zuora.com/developer/api-reference/#operation/POST_BillingPreview

We use this to check the invoice charge amount at the price rise date.

Note we have to manually add the tax as the endpoint currently does not account for tax.
