### PR TITLE
Exclude discounts from post-price-rise invoice amount checks

### DIFF
--- a/src/main/scala/com/gu/Main.scala
+++ b/src/main/scala/com/gu/Main.scala
@@ -75,7 +75,7 @@ object Main extends App with LazyLogging {
             Abort(s"Failed price rise request for ${priceRise.subscriptionName}: $priceRiseResponse")
           val subscriptionAfter = ZuoraClient.getSubscription(priceRise.subscriptionName)
           val accountAfter = ZuoraClient.getAccount(subscriptionBefore.accountNumber)
-          val invoiceItem = ZuoraClient.billingPreview(accountAfter, priceRise)
+          val invoiceItem = ZuoraClient.newGuardianWeeklyInvoicePreview(accountAfter, priceRise)
           val unsatisfiedPostConditions = CheckPriceRisePostConditions(subscriptionAfter, accountBefore, accountAfter, newGuardianWeeklyProductCatalogue, priceRise, currentSubscription, invoiceItem)
           if (unsatisfiedPostConditions.nonEmpty)
             Abort(s"${priceRise.subscriptionName} failed because of unsatisfied post-conditions: $unsatisfiedPostConditions")

--- a/src/main/scala/com/gu/ZuoraClient.scala
+++ b/src/main/scala/com/gu/ZuoraClient.scala
@@ -260,7 +260,7 @@ object ZuoraClient extends ZuoraJsonFormats {
     }
   }
 
-  def billingPreview(
+  def newGuardianWeeklyInvoicePreview(
     account: Account,
     priceRise: PriceRise,
   ): InvoiceItem = {

--- a/src/main/scala/com/gu/ZuoraClient.scala
+++ b/src/main/scala/com/gu/ZuoraClient.scala
@@ -273,9 +273,9 @@ object ZuoraClient extends ZuoraJsonFormats {
       .asString
 
     response.code match {
-      case 200 => (parse(response.body) \ "invoiceItems").extract[List[InvoiceItem]].headOption match {
-        case Some(invoiceItem) => invoiceItem
-        case None => throw new RuntimeException(s"No invoice found for $body: $response")
+      case 200 => (parse(response.body) \ "invoiceItems").extract[List[InvoiceItem]].filter(_.productName != "Discounts") match {
+        case List(singleInvoiceItem) => singleInvoiceItem
+        case _ => throw new RuntimeException(s"Expected to find a single invoice item after excluding Discounts, but got $body: $response")
       }
       case _ => throw new RuntimeException(s"${account.basicInfo.id} failed to get billing preview due to Zuora networking issue: $response")
     }


### PR DESCRIPTION
Otherwise this check fails if the user has a holiday credit on their account.

We also now check that there is only a single item (charge) in the list of invoice items, in order to protect against the case where we are accidentally charging users for multiple products at once.