### PR TITLE
Do not remove old Guardian Weekly rate plans

### DIFF
--- a/src/main/scala/com/gu/RemoveRatePlans.scala
+++ b/src/main/scala/com/gu/RemoveRatePlans.scala
@@ -3,7 +3,7 @@ package com.gu
 import com.gu.FileImporter.PriceRise
 
 /**
-  * Remove all rate plans but Holiday and Retention Discount
+  * Remove current guardian weekly (only), and all discounts except holiday and retention.
   */
 object RemoveRatePlans {
   def apply(
@@ -12,15 +12,18 @@ object RemoveRatePlans {
       priceRise: PriceRise
   ): List[RemoveRatePlan] = {
 
+    val removeCurrentGuardianWeeklySubscriptionRatePlan =
+      List(RemoveRatePlan(currentGuardianWeeklySubscription.ratePlanId, priceRise.priceRiseDate))
+
     import Config.Zuora._
-    val removeRatePlans: List[RemoveRatePlan] =
+    val removeDiscountsOtherThanHolidayAndRetention: List[RemoveRatePlan] =
       subscription
         .ratePlans
         .filterNot(ratePlan => doNotRemoveProductRatePlanIds.contains(ratePlan.productRatePlanId))
+        .filter(_.productName == "Discounts")
         .map(ratePlan => RemoveRatePlan(ratePlan.id, priceRise.priceRiseDate))
 
-    assert(removeRatePlans.map(_.ratePlanId).contains(currentGuardianWeeklySubscription.ratePlanId), "Current Guardian Weekly rate plan should be removed.")
-    removeRatePlans
+    removeCurrentGuardianWeeklySubscriptionRatePlan ++ removeDiscountsOtherThanHolidayAndRetention
   }
 
 }

--- a/src/main/scala/com/gu/ZuoraClient.scala
+++ b/src/main/scala/com/gu/ZuoraClient.scala
@@ -26,7 +26,8 @@ case class RatePlan(
   lastChangeType: Option[String],
   productRatePlanId: String,
   ratePlanName: String,
-  ratePlanCharges: List[RatePlanCharge]
+  ratePlanCharges: List[RatePlanCharge],
+  productName: String
 )
 
 case class Subscription(


### PR DESCRIPTION
When processing a price rise, all old rate plans were being removed from a subscription. Bizarrely, Zuora will allow you to re-remove a rate plan which has already been removed by a prior operation (e.g. a manual renewal of a one-off plan), creating a new amendment as a side-effect, that is, removal of the same rate plan is NOT idempotent. According to [this clause](https://github.com/guardian/fulfilment-lambdas/blob/master/src/weekly/query.js#L60-L61) in the fulfilment query, any old Guardian Weekly rate plan which was re-removed became eligible for fulfilment again between the time of price rise script execution and the user’s price rise date.