### PR TITLE
Retry billing preview on optimistic locking failed

### DIFF
--- a/src/main/scala/com/gu/BillRunVerifier.scala
+++ b/src/main/scala/com/gu/BillRunVerifier.scala
@@ -16,6 +16,7 @@ object BillRunVerifier extends App with LazyLogging {
   val billRunImport = BillRunFileImporter.importCsv(billRunFilename)
 
   var verified = true
+  var priceRiseApplied = 0
 
   logger.info(s"Start verifying bill run $billRunFilename against $priceRiseFilename...")
   csvImport.foreach {
@@ -28,6 +29,7 @@ object BillRunVerifier extends App with LazyLogging {
         .foreach { invoice =>
           if (invoice.InvoiceTotalAmount == priceRise.newPrice && invoice.invoiceDate.isEqual(priceRise.priceRiseDate)) {
             //            logger.info(s"$invoice === $priceRise")
+            priceRiseApplied = 1 + priceRiseApplied
           }
           else {
             verified = false
@@ -37,6 +39,7 @@ object BillRunVerifier extends App with LazyLogging {
   }
 
   logger.info(s"Finished verifying bill run $billRunFilename against $priceRiseFilename")
+  logger.info(s"Price rise applied count = $priceRiseApplied (${math.floor((priceRiseApplied.toFloat * 100) / csvImport.size)}%)")
   if (verified)
     logger.info(Console.GREEN + s"All OK.")
 }


### PR DESCRIPTION
Retry [Billing Preview call](https://www.zuora.com/developer/api-reference/#operation/POST_BillingPreview) as it keeps failing due to `optimistic locking failed`:

```
{
	"success": false,
	"processId": "3234C1527FB1625A",
	"reasons": [{
		"code": 59870050,
		"message": "Object of class [com.zuora.zbilling.subscription.model.Subscription] with identifier [2c92a00768a2b3890168a35e2ded3e28]: optimistic locking failed; nested exception is org.hibernate.StaleObjectStateException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect): [com.zuora.zbilling.subscription.model.Subscription#2c92a00768a2b3890168a35e2ded3e28]"
	}]
}
```