### PR TITLE
Price rise only after one year

### DIFF
--- a/src/main/scala/com/gu/AtLeastOneYearPassed.scala
+++ b/src/main/scala/com/gu/AtLeastOneYearPassed.scala
@@ -1,0 +1,8 @@
+package com.gu
+
+import org.joda.time.{LocalDate, Years}
+
+object AtLeastOneYearPassed {
+  def apply(start: LocalDate, end: LocalDate): Boolean =
+    Years.yearsBetween(start, end).getYears >= 1
+}

--- a/src/main/scala/com/gu/CheckPriceRisePreConditions.scala
+++ b/src/main/scala/com/gu/CheckPriceRisePreConditions.scala
@@ -11,6 +11,7 @@ case object TargetPriceRiseIsNotMoreThanDefaultProductRatePlanChargePrice extend
 case object TargetPriceRiseIsMoreThanTheCurrentPrice extends PriceRisePreCondition
 case object CurrentlyActiveProductRatePlanIsGuardianWeeklyRatePlan extends PriceRisePreCondition
 case object BillingPeriodIsQuarterlyOrAnnually extends PriceRisePreCondition
+case object SubscribedForAtLeast12MonthsBeforePriceRise extends PriceRisePreCondition
 
 /**
   * Check pre-conditions, before price rise is written to Zuora, by cross-referencing
@@ -39,6 +40,7 @@ object CheckPriceRisePreConditions {
       TargetPriceRiseIsMoreThanTheCurrentPrice -> (priceRise.newPrice > currentGuardianWeeklySubscription.price),
       CurrentlyActiveProductRatePlanIsGuardianWeeklyRatePlan -> Config.Zuora.Old.guardianWeeklyProductRatePlanIds.contains(currentGuardianWeeklySubscription.productRatePlanId),
       BillingPeriodIsQuarterlyOrAnnually -> List("Annual", "Quarter").contains(currentGuardianWeeklySubscription.billingPeriod),
+      SubscribedForAtLeast12MonthsBeforePriceRise -> AtLeastOneYearPassed(subscription.customerAcceptanceDate, priceRise.priceRiseDate)
     ).partition(_._2)
 
     unsatisfied.map(_._1)

--- a/src/test/scala/com/gu/AtLeastOneYearPassedSpec.scala
+++ b/src/test/scala/com/gu/AtLeastOneYearPassedSpec.scala
@@ -1,0 +1,27 @@
+package com.gu
+
+import org.joda.time.LocalDate
+import org.joda.time.format.DateTimeFormat
+import org.scalatest._
+
+class AtLeastOneYearPassedSpec extends FlatSpec with Matchers {
+  val zuoraDateFormat = DateTimeFormat.forPattern("yyyy-MM-dd")
+
+  "AtLeastOneYearPassed" should "include the bounds" in {
+    val start = LocalDate.parse("2018-01-01", zuoraDateFormat)
+    val end = LocalDate.parse("2019-01-01", zuoraDateFormat)
+    AtLeastOneYearPassed(start, end) should be(true)
+  }
+
+  it should "return false if one day before" in {
+    val start = LocalDate.parse("2018-01-01", zuoraDateFormat)
+    val end = LocalDate.parse("2018-12-31", zuoraDateFormat)
+    AtLeastOneYearPassed(start, end) should be(false)
+  }
+
+  it should "return true if few years passed" in {
+    val start = LocalDate.parse("2018-01-01", zuoraDateFormat)
+    val end = LocalDate.parse("2069-12-31", zuoraDateFormat)
+    AtLeastOneYearPassed(start, end) should be(true)
+  }
+}


### PR DESCRIPTION
Add precondition where at least one year passed between current subscription `customerAcceptanceDate` and price rise date.
