### PR TITLE
Handle price rises scheduled for up to one year in the future

### DIFF
--- a/src/main/scala/com/gu/CheckPriceRisePreConditions.scala
+++ b/src/main/scala/com/gu/CheckPriceRisePreConditions.scala
@@ -5,7 +5,7 @@ import com.gu.FileImporter.PriceRise
 trait PriceRisePreCondition
 case object SubscriptionIsAutoRenewable extends PriceRisePreCondition
 case object SubscriptionIsActive extends PriceRisePreCondition
-case object PriceRiseDateIsOnInvoicedPeriodEndDate extends PriceRisePreCondition
+case object PriceRiseDateIsOnProjectedPaymentDay extends PriceRisePreCondition
 case object TargetPriceRiseIsNotMoreThanTheCap extends PriceRisePreCondition
 case object TargetPriceRiseIsNotMoreThanDefaultProductRatePlanChargePrice extends PriceRisePreCondition
 case object TargetPriceRiseIsMoreThanTheCurrentPrice extends PriceRisePreCondition
@@ -34,7 +34,11 @@ object CheckPriceRisePreConditions {
     val (_, unsatisfied) = List[(PriceRisePreCondition, Boolean)](
       SubscriptionIsAutoRenewable -> subscription.autoRenew,
       SubscriptionIsActive -> (subscription.status == "Active"),
-      PriceRiseDateIsOnInvoicedPeriodEndDate -> currentGuardianWeeklySubscription.invoicedPeriod.endDateExcluding.isEqual(priceRise.priceRiseDate),
+      PriceRiseDateIsOnProjectedPaymentDay -> PriceRiseFallsOnAcceptableDay(
+        priceRise.priceRiseDate,
+        currentGuardianWeeklySubscription.invoicedPeriod.endDateExcluding,
+        currentGuardianWeeklySubscription.billingPeriod
+      ),
       TargetPriceRiseIsNotMoreThanTheCap -> (priceRise.newPrice < currentGuardianWeeklySubscription.price * Config.priceRiseFactorCap),
       TargetPriceRiseIsNotMoreThanDefaultProductRatePlanChargePrice -> (priceRise.newPrice <= CatalogPriceExceptNZ(futureGuardianWeeklyProducts, currentGuardianWeeklySubscription)),
       TargetPriceRiseIsMoreThanTheCurrentPrice -> (priceRise.newPrice > currentGuardianWeeklySubscription.price),

--- a/src/main/scala/com/gu/PriceRiseFallsOnAcceptableDay.scala
+++ b/src/main/scala/com/gu/PriceRiseFallsOnAcceptableDay.scala
@@ -1,0 +1,16 @@
+package com.gu
+
+import org.joda.time.LocalDate
+
+object PriceRiseFallsOnAcceptableDay {
+
+  def apply(priceRiseDate: LocalDate, firstDayOfNextInvoicePeriod: LocalDate, billingPeriod: String) = {
+    val acceptablePriceRiseDates = if (billingPeriod == "Quarter") {
+      List(firstDayOfNextInvoicePeriod, firstDayOfNextInvoicePeriod.plusMonths(3), firstDayOfNextInvoicePeriod.plusMonths(6), firstDayOfNextInvoicePeriod.plusMonths(9))
+    } else {
+      List(firstDayOfNextInvoicePeriod)
+    }
+    acceptablePriceRiseDates.contains(priceRiseDate)
+  }
+
+}

--- a/src/test/scala/com/gu/PriceRiseFallsOnAcceptableDaySpec.scala
+++ b/src/test/scala/com/gu/PriceRiseFallsOnAcceptableDaySpec.scala
@@ -1,0 +1,51 @@
+package com.gu
+
+import org.joda.time.LocalDate
+import org.joda.time.format.DateTimeFormat
+import org.scalatest._
+
+class PriceRiseFallsOnAcceptableDaySpec extends FlatSpec with Matchers {
+
+  val zuoraDateFormat = DateTimeFormat.forPattern("yyyy-MM-dd")
+
+  "PriceRiseFallsOnAcceptableDay" should "return true if the price will go up on the next invoice date (annual)" in {
+    PriceRiseFallsOnAcceptableDay(
+      LocalDate.parse("2019-03-25", zuoraDateFormat),
+      LocalDate.parse("2019-03-25", zuoraDateFormat),
+      "Annual"
+    ) should be(true)
+  }
+
+  "PriceRiseFallsOnAcceptableDay" should "return true if the price will go up on the next invoice date (quarterly)" in {
+    PriceRiseFallsOnAcceptableDay(
+      LocalDate.parse("2019-03-25", zuoraDateFormat),
+      LocalDate.parse("2019-03-25", zuoraDateFormat),
+      "Quarter"
+    ) should be(true)
+  }
+
+  "PriceRiseFallsOnAcceptableDay" should "return true if the price will go up 2 quarters after the next invoice date" in {
+    PriceRiseFallsOnAcceptableDay(
+      LocalDate.parse("2019-09-25", zuoraDateFormat),
+      LocalDate.parse("2019-03-25", zuoraDateFormat),
+      "Quarter"
+    ) should be(true)
+  }
+
+  "PriceRiseFallsOnAcceptableDay" should "return false if the price will go up before the next expected invoice" in {
+    PriceRiseFallsOnAcceptableDay(
+      LocalDate.parse("2019-03-24", zuoraDateFormat),
+      LocalDate.parse("2019-03-25", zuoraDateFormat),
+      "Quarter"
+    ) should be(false)
+  }
+
+  "PriceRiseFallsOnAcceptableDay" should "return false if the price will go up on a date which doesn't align with the normal quarterly payment schedule" in {
+    PriceRiseFallsOnAcceptableDay(
+      LocalDate.parse("2019-03-27", zuoraDateFormat),
+      LocalDate.parse("2019-09-25", zuoraDateFormat),
+      "Quarter"
+    ) should be(false)
+  }
+
+}


### PR DESCRIPTION
Now that we are processing all price rises for the rest of the year (as opposed to a week by week batch of price rises), we need to cope with cases where price rise date != next invoice date.