### PR TITLE
Handle price rises scheduled for one year in the future attempt 2

### DIFF
--- a/src/main/scala/com/gu/DryRunner.scala
+++ b/src/main/scala/com/gu/DryRunner.scala
@@ -43,9 +43,10 @@ object DryRunner extends App with LazyLogging {
       else {
         val currentSubscription = CurrentGuardianWeeklySubscription(subscriptionBefore, accountBefore)
         val priceRiseRequest = PriceRiseRequestBuilder(subscriptionBefore, currentSubscription, newGuardianWeeklyProductCatalogue, priceRise)
+        val projectedInvoiceItems = ZuoraClient.guardianWeeklyInvoicePreview(accountBefore)
 
         val unsatisfiedPreConditions =
-          CheckPriceRisePreConditions(priceRise, subscriptionBefore, accountBefore, newGuardianWeeklyProductCatalogue
+          CheckPriceRisePreConditions(priceRise, subscriptionBefore, accountBefore, projectedInvoiceItems, newGuardianWeeklyProductCatalogue
           ) ++ CheckPriceRiseRequestPreConditions(priceRiseRequest, currentSubscription)
 
         if(unsatisfiedPreConditions.nonEmpty) {

--- a/src/main/scala/com/gu/PriceRiseFallsOnAcceptableDay.scala
+++ b/src/main/scala/com/gu/PriceRiseFallsOnAcceptableDay.scala
@@ -4,13 +4,8 @@ import org.joda.time.LocalDate
 
 object PriceRiseFallsOnAcceptableDay {
 
-  def apply(priceRiseDate: LocalDate, firstDayOfNextInvoicePeriod: LocalDate, billingPeriod: String) = {
-    val acceptablePriceRiseDates = if (billingPeriod == "Quarter") {
-      List(firstDayOfNextInvoicePeriod, firstDayOfNextInvoicePeriod.plusMonths(3), firstDayOfNextInvoicePeriod.plusMonths(6), firstDayOfNextInvoicePeriod.plusMonths(9))
-    } else {
-      List(firstDayOfNextInvoicePeriod)
-    }
-    acceptablePriceRiseDates.contains(priceRiseDate)
+  def apply(priceRiseDate: LocalDate, projectedInvoiceItems: List[InvoiceItem]) = {
+    projectedInvoiceItems.map(_.serviceStartDate).contains(priceRiseDate)
   }
 
 }

--- a/src/test/scala/com/gu/PriceRiseFallsOnAcceptableDaySpec.scala
+++ b/src/test/scala/com/gu/PriceRiseFallsOnAcceptableDaySpec.scala
@@ -8,43 +8,49 @@ class PriceRiseFallsOnAcceptableDaySpec extends FlatSpec with Matchers {
 
   val zuoraDateFormat = DateTimeFormat.forPattern("yyyy-MM-dd")
 
-  "PriceRiseFallsOnAcceptableDay" should "return true if the price will go up on the next invoice date (annual)" in {
-    PriceRiseFallsOnAcceptableDay(
-      LocalDate.parse("2019-03-25", zuoraDateFormat),
-      LocalDate.parse("2019-03-25", zuoraDateFormat),
-      "Annual"
-    ) should be(true)
-  }
+  def invoiceItem(
+    start: LocalDate
+  ) = InvoiceItem(
+    "invItem123",
+    "A-S12345678",
+    start,
+    start.plusMonths(3).minusDays(1),
+    10,
+    "Weekly Charge",
+    "Guardian Weekly"
+  )
 
-  "PriceRiseFallsOnAcceptableDay" should "return true if the price will go up on the next invoice date (quarterly)" in {
+  val standardQuarterlyPaymentSchedule = List(
+    invoiceItem(LocalDate.parse("2019-03-25", zuoraDateFormat)),
+    invoiceItem(LocalDate.parse("2019-06-25", zuoraDateFormat)),
+    invoiceItem(LocalDate.parse("2019-09-25", zuoraDateFormat))
+  )
+
+  "PriceRiseFallsOnAcceptableDay" should "return true if the price will go up on the next invoice date" in {
     PriceRiseFallsOnAcceptableDay(
       LocalDate.parse("2019-03-25", zuoraDateFormat),
-      LocalDate.parse("2019-03-25", zuoraDateFormat),
-      "Quarter"
+      standardQuarterlyPaymentSchedule
     ) should be(true)
   }
 
   "PriceRiseFallsOnAcceptableDay" should "return true if the price will go up 2 quarters after the next invoice date" in {
     PriceRiseFallsOnAcceptableDay(
       LocalDate.parse("2019-09-25", zuoraDateFormat),
-      LocalDate.parse("2019-03-25", zuoraDateFormat),
-      "Quarter"
+      standardQuarterlyPaymentSchedule
     ) should be(true)
   }
 
   "PriceRiseFallsOnAcceptableDay" should "return false if the price will go up before the next expected invoice" in {
     PriceRiseFallsOnAcceptableDay(
       LocalDate.parse("2019-03-24", zuoraDateFormat),
-      LocalDate.parse("2019-03-25", zuoraDateFormat),
-      "Quarter"
+      standardQuarterlyPaymentSchedule
     ) should be(false)
   }
 
   "PriceRiseFallsOnAcceptableDay" should "return false if the price will go up on a date which doesn't align with the normal quarterly payment schedule" in {
     PriceRiseFallsOnAcceptableDay(
       LocalDate.parse("2019-03-27", zuoraDateFormat),
-      LocalDate.parse("2019-09-25", zuoraDateFormat),
-      "Quarter"
+      standardQuarterlyPaymentSchedule
     ) should be(false)
   }
 


### PR DESCRIPTION
The approach I tried in https://github.com/guardian/zuora-price-riser/pull/43 would not work in all scenarios.

For example, consider a user who signed up for a quarterly plan on `2018-01-31` and is due for a price rise on `2019-07-31`. Zuora will always charge this user on the last day of the month. If the current next invoice date is `2019-04-30` the old logic considered `2019-07-30`  (and not `2019-07-31`) to be a valid price rise date.

The new approach relies on Zuora's billing preview functionality instead of attempting to manage this logic ourselves.

Whilst making this change I also noticed that the post-checks would fail since they were expecting a single invoice to be returned by the billing preview. This expectation is invalid now that some price rises will not take place for several months, so I've tweaked the logic accordingly.