### PR TITLE
Remove date letter sent from output row

### DIFF
--- a/src/main/scala/com/gu/FileImporter.scala
+++ b/src/main/scala/com/gu/FileImporter.scala
@@ -32,7 +32,7 @@ object FileImporter extends LazyLogging {
     termEndDate: term_end_date
   ) {
     def logOutputRow(autoRenew: Boolean, skipReasons: List[SkipReason]) = {
-      val priceRiseOutputCsvRow = s"$subscriptionName,$campaignName,$dateLetterSent,$priceRiseDate,${_unsafeCurrentPrice},$newPrice,${termEndDate.getOrElse("")},${autoRenew}"
+      val priceRiseOutputCsvRow = s"$subscriptionName,$campaignName,$priceRiseDate,${_unsafeCurrentPrice},$newPrice,${termEndDate.getOrElse("")},${autoRenew}"
       skipReasons match {
         case list if list.contains(PriceRiseApplied) => logger.info(s"PRICE RISE APPLIED:$priceRiseOutputCsvRow")
         case list if list.contains(OneOff) => logger.info(s"ONE-OFF:$priceRiseOutputCsvRow")


### PR DESCRIPTION
Some manual fixes to the data are required. This means that the 'date_letter_sent' column from the input file is not going to be 100% accurate.

We do not need this date and nor does Izabela. This date is only used by Salesforce for CSR display, and it is just a calculation of 56 days before the price rise date. 

Consequently the simplest solution is to make date letter sent a formula field in Salesforce, or add a new column to the CSV (which calculate this) before uploading to Salesforce. It will be omitted from the DL table altogether.