### PR TITLE
Allow term extension logic to cope with cases where price rise date is later than next invoice date

### DIFF
--- a/src/main/scala/com/gu/DryRunner.scala
+++ b/src/main/scala/com/gu/DryRunner.scala
@@ -61,7 +61,7 @@ object DryRunner extends App with LazyLogging {
           readyToApplyCount = readyToApplyCount + 1
           logger.info(s"${subscriptionBefore.subscriptionNumber} ready to apply")
 
-          if (ExtendTermRequestBuilder(subscriptionBefore, currentSubscription).isDefined)
+          if (ExtendTermRequestBuilder(subscriptionBefore, priceRise.priceRiseDate).isDefined)
             termExtensionCount = termExtensionCount + 1
         }
       }

--- a/src/main/scala/com/gu/ExtendTermRequestBuilder.scala
+++ b/src/main/scala/com/gu/ExtendTermRequestBuilder.scala
@@ -1,27 +1,27 @@
 package com.gu
 
 import com.gu.ZuoraClient.ExtendTerm
-import org.joda.time.Days
+import org.joda.time.{Days, LocalDate}
 
 sealed trait ExtendTermPreCondition
-case object TermEndDateIsBeforeInvoicePeriodEndDate extends ExtendTermPreCondition
+case object TermEndDateIsBeforePriceRiseDate extends ExtendTermPreCondition
 
 /**
   * Optionally extend term if subscriptions is annual and invoice period is beyond term end date.
   */
 object ExtendTermRequestBuilder {
   def apply(
-      subscription: Subscription,
-      currentGuardianWeeklySubscription: CurrentGuardianWeeklySubscription
+    subscription: Subscription,
+    priceRiseDate: LocalDate
   ): Option[ExtendTerm] = {
 
     val (_, unsatisfied) = List(
-      TermEndDateIsBeforeInvoicePeriodEndDate -> subscription.termEndDate.isBefore(currentGuardianWeeklySubscription.invoicedPeriod.endDateExcluding)
+      TermEndDateIsBeforePriceRiseDate -> subscription.termEndDate.isBefore(priceRiseDate)
     ).partition(_._2)
 
     if (unsatisfied.isEmpty) {
       val extensionInDays =
-        Days.daysBetween(subscription.termEndDate, currentGuardianWeeklySubscription.invoicedPeriod.endDateExcluding).getDays
+        Days.daysBetween(subscription.termEndDate, priceRiseDate).getDays
 
       Some(ExtendTerm(
         currentTerm = (365 + extensionInDays).toString,

--- a/src/main/scala/com/gu/Main.scala
+++ b/src/main/scala/com/gu/Main.scala
@@ -68,7 +68,7 @@ object Main extends App with LazyLogging {
           // **********************************************************************************************
           // 3. MUTATE
           // **********************************************************************************************
-          ExtendTermRequestBuilder(subscriptionBefore, currentSubscription).map(extendTerm => ZuoraClient.extendTerm(priceRise.subscriptionName, extendTerm))
+          ExtendTermRequestBuilder(subscriptionBefore, priceRise.priceRiseDate).map(extendTerm => ZuoraClient.extendTerm(priceRise.subscriptionName, extendTerm))
           val priceRiseResponse = ZuoraClient.removeAndAddAProductRatePlan(priceRise.subscriptionName, priceRiseRequest)
 
           // **********************************************************************************************

--- a/src/test/scala/com/gu/ExtendTermRequestBuilderSpec.scala
+++ b/src/test/scala/com/gu/ExtendTermRequestBuilderSpec.scala
@@ -1,7 +1,7 @@
 package com.gu
 
 import com.gu.ZuoraClient.ExtendTerm
-import org.joda.time.{DateTimeUtils, Instant}
+import org.joda.time.{DateTimeUtils, Instant, LocalDate}
 import org.json4s.native.JsonMethods.parse
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -10,24 +10,19 @@ import scala.io.Source
 class ExtendTermRequestBuilderSpec extends FlatSpec with Matchers with ZuoraJsonFormats {
   DateTimeUtils.setCurrentMillisFixed(Instant.parse("2018-12-15").getMillis)
   val subscriptionRaw = Source.fromURL(getClass.getResource("/current-subscription.json")).mkString
-  val accountRaw = Source.fromURL(getClass.getResource("/current-subscription-account.json")).mkString
   val subscription = parse(subscriptionRaw).extract[Subscription]
-  val account = parse(accountRaw).extract[Account]
-  val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, account)
 
-  "ExtendTerm" should "should be created if invoiced period is outside term" in {
+  "ExtendTerm" should "be created if the price rise date is outside of the term end date" in {
     ExtendTermRequestBuilder(
-      subscription,
-      currentGuardianWeeklySubscription
-    ) should be (Some(ExtendTerm((365 + 9).toString, "Day"))) // "chargedThroughDate": "2019-07-27", "termEndDate": "2019-07-18"
+      subscription, // "termEndDate": "2019-07-18",
+      LocalDate.parse("2019-07-28")
+    ) should be (Some(ExtendTerm((365 + 10).toString, "Day")))
   }
 
-  it should "not extend term if invoice period end date is equal to term end date" in {
+  it should "not extend term if price rise date is equal to term end date" in {
     ExtendTermRequestBuilder(
       subscription,
-      currentGuardianWeeklySubscription.copy(
-        invoicedPeriod = currentGuardianWeeklySubscription.invoicedPeriod.copy(endDateExcluding = subscription.termEndDate)
-      )
+      LocalDate.parse("2019-07-18")
     ) should be (None)
   }
 }


### PR DESCRIPTION
Since we now accept price rise dates which are after the next invoice date, we need to tweak the term extension logic accordingly.