### PR TITLE
Add safety check to ensure that nobody gets a price rise without receiving a letter

### DIFF
--- a/src/main/scala/com/gu/CheckPriceRisePreConditions.scala
+++ b/src/main/scala/com/gu/CheckPriceRisePreConditions.scala
@@ -1,6 +1,7 @@
 package com.gu
 
 import com.gu.FileImporter.PriceRise
+import org.joda.time.LocalDate
 
 trait PriceRisePreCondition
 case object SubscriptionIsAutoRenewable extends PriceRisePreCondition
@@ -12,6 +13,7 @@ case object TargetPriceRiseIsMoreThanTheCurrentPrice extends PriceRisePreConditi
 case object CurrentlyActiveProductRatePlanIsGuardianWeeklyRatePlan extends PriceRisePreCondition
 case object BillingPeriodIsQuarterlyOrAnnually extends PriceRisePreCondition
 case object SubscribedForAtLeast12MonthsBeforePriceRise extends PriceRisePreCondition
+case object ThereIsStillTimeToPostALetter extends PriceRisePreCondition
 
 /**
   * Check pre-conditions, before price rise is written to Zuora, by cross-referencing
@@ -34,6 +36,7 @@ object CheckPriceRisePreConditions {
     val (_, unsatisfied) = List[(PriceRisePreCondition, Boolean)](
       SubscriptionIsAutoRenewable -> subscription.autoRenew,
       SubscriptionIsActive -> (subscription.status == "Active"),
+      ThereIsStillTimeToPostALetter -> priceRise.priceRiseDate.isAfter(LocalDate.parse("2019-05-12")),
       PriceRiseDateIsOnProjectedPaymentDay -> PriceRiseFallsOnAcceptableDay(priceRise.priceRiseDate, projectedInvoiceItemsBeforePriceRise),
       TargetPriceRiseIsNotMoreThanTheCap -> (priceRise.newPrice < currentGuardianWeeklySubscription.price * Config.priceRiseFactorCap),
       TargetPriceRiseIsNotMoreThanDefaultProductRatePlanChargePrice -> (priceRise.newPrice <= CatalogPriceExceptNZ(futureGuardianWeeklyProducts, currentGuardianWeeklySubscription)),

--- a/src/main/scala/com/gu/CheckPriceRisePreConditions.scala
+++ b/src/main/scala/com/gu/CheckPriceRisePreConditions.scala
@@ -2,6 +2,7 @@ package com.gu
 
 import com.gu.FileImporter.PriceRise
 import org.joda.time.LocalDate
+import org.joda.time.format.DateTimeFormat
 
 trait PriceRisePreCondition
 case object SubscriptionIsAutoRenewable extends PriceRisePreCondition
@@ -36,7 +37,7 @@ object CheckPriceRisePreConditions {
     val (_, unsatisfied) = List[(PriceRisePreCondition, Boolean)](
       SubscriptionIsAutoRenewable -> subscription.autoRenew,
       SubscriptionIsActive -> (subscription.status == "Active"),
-      ThereIsStillTimeToPostALetter -> priceRise.priceRiseDate.isAfter(LocalDate.parse("2019-05-12")),
+      ThereIsStillTimeToPostALetter -> priceRise.priceRiseDate.isAfter(LocalDate.parse("2019-05-12", DateTimeFormat.forPattern("yyyy-MM-dd"))),
       PriceRiseDateIsOnProjectedPaymentDay -> PriceRiseFallsOnAcceptableDay(priceRise.priceRiseDate, projectedInvoiceItemsBeforePriceRise),
       TargetPriceRiseIsNotMoreThanTheCap -> (priceRise.newPrice < currentGuardianWeeklySubscription.price * Config.priceRiseFactorCap),
       TargetPriceRiseIsNotMoreThanDefaultProductRatePlanChargePrice -> (priceRise.newPrice <= CatalogPriceExceptNZ(futureGuardianWeeklyProducts, currentGuardianWeeklySubscription)),


### PR DESCRIPTION
There are some rows in the full file which indicate that a price rise should have _already_ been applied. 

If we've already sent a letter and applied the price rise this is not a problem - the script will just [skip](https://github.com/guardian/zuora-price-riser/blob/master/src/main/scala/com/gu/Main.scala#L48-L53) over the row. 

Although _skipping_ is acceptable, we should not be _applying_ a price rise to any subscription with a price rise date before `2019-05-12` as part of the full run. 

This is technically possible, but is likely to indicate that the subscription was missed when the letters for that price rise period were sent. Therefore it's safer to refuse to process the price rise altogether in such cases.

_N.B. The next set of letters will target users with a price rise date between 13th May and 19th May_